### PR TITLE
Moved off script checks to Hivemind and a loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,13 @@ ADD nginx.conf /etc/nginx/nginx.conf
 ADD /scripts /fly
 ENV NGINX_PORT=8080
 
-CMD ["/fly/start.sh"]
+
+RUN curl -L https://github.com/DarthSim/hivemind/releases/download/v1.1.0/hivemind-v1.1.0-linux-amd64.gz -o hivemind.gz \
+  && gunzip hivemind.gz \
+  && mv hivemind /usr/local/bin
+
+COPY Procfile Procfile
+RUN chmod +x /usr/local/bin/hivemind
+RUN chmod +x /fly/*.sh
+
+CMD ["/usr/local/bin/hivemind"]

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: /fly/start.sh
+cluster: /fly/check-loop.sh

--- a/fly.toml
+++ b/fly.toml
@@ -12,6 +12,7 @@ destination = "/data"
 [[services]]
   internal_port = 8080
   protocol = "tcp"
+  script_checks = []
 
   [services.concurrency]
     type = "requests"
@@ -35,9 +36,3 @@ destination = "/data"
     restart_limit = 0
     [services.http_checks.headers]
       Host = "health.check"
-
-  [[services.script_checks]]
-    interval = 10000
-    timeout = 1000
-    command = "/fly/check-nodes.sh"
-    restart_limit = 0

--- a/scripts/check-loop.sh
+++ b/scripts/check-loop.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+echo "Checking for new peer instances every 5 seconds." 
+sleep 5
+while true; do    
+    /fly/check-nodes.sh    
+    sleep 5
+done


### PR DESCRIPTION
The earlier script check wasn't working, kept posting the 
```
74e276f6f095135581e5b3525700560a critical 90247ebb   maa    SCRIPT 3m8s ago     rpc error: code = Unknown desc    
                                                                                = Post "http://unix/v1/exec":     
                                                                                EOF  
```
error, which caused all allocations to be marked as unhealthy. 

This update moves to the Hivemind process manager with a bash loop. 